### PR TITLE
removed unnecessary dependency on Google Play Services

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -65,7 +65,6 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:22.0.0'
-    compile 'com.google.android.gms:play-services:7.0.0'
     compile 'com.android.support:support-v4:22.0.0'
 }
 


### PR DESCRIPTION
The gradle build file contains a dependency on Google Play Services that isn't needed to build the app. Removing it would make the build smaller and make it easier to build on F-Droid.
